### PR TITLE
api: add VALR-style HMAC auth for orders; enforce application/json

### DIFF
--- a/api/bin/main/com/valr/api/Application.kt
+++ b/api/bin/main/com/valr/api/Application.kt
@@ -71,9 +71,11 @@ class ApiVerticle : CoroutineVerticle() {
             }
         }
 
-        // Submit limit order: /api/v1/orders/:symbol
+        // Submit limit order: /api/orders/:symbol (authenticated)
         // Body: { "side": "BUY|SELL", "price": "123.45", "quantity": "1.234" }
-        router.post("/api/orders/:symbol").handler { ctx ->
+        router.post("/api/orders/:symbol")
+                .handler(HmacAuthHandler())
+                .handler { ctx ->
             launch {
                 try {
                     val symbol = ctx.pathParam("symbol")

--- a/api/bin/main/com/valr/api/Auth.kt
+++ b/api/bin/main/com/valr/api/Auth.kt
@@ -1,0 +1,105 @@
+package com.valr.api
+
+import io.vertx.core.Handler
+import io.vertx.ext.web.RoutingContext
+import java.time.Clock
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/** Simple in-memory API key store (dev-only). */
+object ApiKeys {
+    private val keys: MutableMap<String, String> = mutableMapOf()
+
+    init {
+        // Load from env if present; otherwise seed a test key for local/dev usage.
+        val envKey = System.getenv("API_KEY")
+        val envSecret = System.getenv("API_SECRET")
+        if (!envKey.isNullOrBlank() && !envSecret.isNullOrBlank()) {
+            keys[envKey] = envSecret
+        } else {
+            keys["test-key"] = "test-secret"
+        }
+    }
+
+    fun secretFor(key: String): String? = keys[key]
+}
+
+/** HMAC (SHA-512) signer compatible with VALR-style concatenation. */
+object HmacSigner {
+    fun sign(secret: String, timestamp: String, verb: String, path: String, body: String): String {
+        val mac = Mac.getInstance("HmacSHA512")
+        mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA512"))
+        mac.update(timestamp.toByteArray())
+        mac.update(verb.uppercase().toByteArray())
+        mac.update(path.toByteArray())
+        mac.update(body.toByteArray())
+        val digest = mac.doFinal()
+        return digest.toHexLower()
+    }
+
+    private fun ByteArray.toHexLower(): String {
+        val sb = StringBuilder(this.size * 2)
+        for (b in this) sb.append(String.format("%02x", b))
+        return sb.toString()
+    }
+}
+
+/**
+ * Vert.x handler enforcing simple VALR-like HMAC auth for mutating requests.
+ * Requires headers: X-VALR-API-KEY, X-VALR-TIMESTAMP, X-VALR-SIGNATURE.
+ * Also enforces content-type application/json for POST/PUT/PATCH.
+ */
+class HmacAuthHandler(private val clock: Clock = Clock.systemUTC()) : Handler<RoutingContext> {
+    override fun handle(ctx: RoutingContext) {
+        val method = ctx.request().method()
+        // For mutating requests enforce JSON content-type
+        if (method.name() == "POST" || method.name() == "PUT" || method.name() == "PATCH") {
+            val ct = ctx.request().getHeader("content-type") ?: ""
+            if (!ct.lowercase().contains("application/json")) {
+                ctx.response()
+                        .setStatusCode(403)
+                        .putHeader("content-type", "application/json")
+                        .end(io.vertx.core.json.Json.encode(ErrorResponse("content-type must be application/json")))
+                return
+            }
+        }
+
+        val apiKey = ctx.request().getHeader("X-VALR-API-KEY")
+        val timestamp = ctx.request().getHeader("X-VALR-TIMESTAMP")
+        val providedSig = ctx.request().getHeader("X-VALR-SIGNATURE")
+
+        if (apiKey.isNullOrBlank() || timestamp.isNullOrBlank() || providedSig.isNullOrBlank()) {
+            ctx.response()
+                    .setStatusCode(403)
+                    .putHeader("content-type", "application/json")
+                    .end(io.vertx.core.json.Json.encode(ErrorResponse("Missing API authentication headers")))
+            return
+        }
+
+        val secret = ApiKeys.secretFor(apiKey)
+        if (secret == null) {
+            ctx.response()
+                    .setStatusCode(403)
+                    .putHeader("content-type", "application/json")
+                    .end(io.vertx.core.json.Json.encode(ErrorResponse("Invalid API key")))
+            return
+        }
+
+        val verb = method.name()
+        val path = ctx.request().path() // exclude host and query
+        val body = ctx.body().asString() ?: ""
+        val expected = HmacSigner.sign(secret, timestamp, verb, path, body)
+
+        if (!expected.equals(providedSig, ignoreCase = true)) {
+            ctx.response()
+                    .setStatusCode(403)
+                    .putHeader("content-type", "application/json")
+                    .end(io.vertx.core.json.Json.encode(ErrorResponse("Invalid signature")))
+            return
+        }
+
+        // Optionally, enforce timestamp freshness (skipped for simplicity in this assessment)
+        ctx.next()
+    }
+}
+

--- a/api/bin/test/com/valr/api/ApplicationTest.kt
+++ b/api/bin/test/com/valr/api/ApplicationTest.kt
@@ -8,6 +8,9 @@ import io.vertx.ext.web.client.HttpResponse
 import io.vertx.ext.web.client.WebClient
 import io.vertx.junit5.VertxExtension
 import io.vertx.junit5.VertxTestContext
+import java.time.Clock
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.*
@@ -53,10 +56,14 @@ class ApplicationTest {
     fun orderLifecycle(testContext: VertxTestContext) {
         val symbol = "TSTLIFE"
 
-        val buyOrder =
-                JsonObject().put("side", "BUY").put("price", "500000.00").put("quantity", "0.01")
+        val buyOrder = JsonObject().put("side", "BUY").put("price", "500000.00").put("quantity", "0.01")
+
+        val (ts, sig) = sign("POST", "/api/orders/$symbol", buyOrder.encode())
 
         client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("X-VALR-API-KEY", "test-key")
+                .putHeader("X-VALR-TIMESTAMP", ts)
+                .putHeader("X-VALR-SIGNATURE", sig)
                 .sendJsonObject(buyOrder)
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -84,7 +91,11 @@ class ApplicationTest {
     fun invalidSideReturns400(testContext: VertxTestContext) {
         val symbol = "TSTBAD"
         val badOrder = JsonObject().put("side", "BUYX").put("price", "1").put("quantity", "1")
+        val (ts, sig) = sign("POST", "/api/orders/$symbol", badOrder.encode())
         client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("X-VALR-API-KEY", "test-key")
+                .putHeader("X-VALR-TIMESTAMP", ts)
+                .putHeader("X-VALR-SIGNATURE", sig)
                 .sendJsonObject(badOrder)
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -100,7 +111,11 @@ class ApplicationTest {
     fun missingFieldsReturnError(testContext: VertxTestContext) {
         val symbol = "TSTMISS"
         val badOrder = JsonObject().put("side", "BUY").put("price", "1") // missing quantity
+        val (ts, sig) = sign("POST", "/api/orders/$symbol", badOrder.encode())
         client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("X-VALR-API-KEY", "test-key")
+                .putHeader("X-VALR-TIMESTAMP", ts)
+                .putHeader("X-VALR-SIGNATURE", sig)
                 .sendJsonObject(badOrder)
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -115,9 +130,13 @@ class ApplicationTest {
         val symbol = "TSTDEPTH"
         val mk = { p: String -> JsonObject().put("side", "BUY").put("price", p).put("quantity", "0.01") }
 
-        client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(mk("100"))
-                .compose { client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(mk("200")) }
-                .compose { client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(mk("300")) }
+        val (ts1, sig1) = sign("POST", "/api/orders/$symbol", mk("100").encode())
+        val (ts2, sig2) = sign("POST", "/api/orders/$symbol", mk("200").encode())
+        val (ts3, sig3) = sign("POST", "/api/orders/$symbol", mk("300").encode())
+
+        client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts1).putHeader("X-VALR-SIGNATURE", sig1).sendJsonObject(mk("100"))
+                .compose { client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts2).putHeader("X-VALR-SIGNATURE", sig2).sendJsonObject(mk("200")) }
+                .compose { client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts3).putHeader("X-VALR-SIGNATURE", sig3).sendJsonObject(mk("300")) }
                 .compose { client.get(8080, "localhost", "/api/orderbook/$symbol?depth=2").send() }
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -135,8 +154,10 @@ class ApplicationTest {
         val symbol = "TSTTRADES"
         val sell = JsonObject().put("side", "SELL").put("price", "10").put("quantity", "1")
         val buy = JsonObject().put("side", "BUY").put("price", "10").put("quantity", "1")
-        client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(sell)
-                .compose { client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(buy) }
+        val (ts1, sig1) = sign("POST", "/api/orders/$symbol", sell.encode())
+        val (ts2, sig2) = sign("POST", "/api/orders/$symbol", buy.encode())
+        client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts1).putHeader("X-VALR-SIGNATURE", sig1).sendJsonObject(sell)
+                .compose { client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts2).putHeader("X-VALR-SIGNATURE", sig2).sendJsonObject(buy) }
                 .compose { client.get(8080, "localhost", "/api/trades/$symbol?limit=1").send() }
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -153,7 +174,8 @@ class ApplicationTest {
         val s1 = "AAAUSD"
         val s2 = "BBBUSD"
         val buy = JsonObject().put("side", "BUY").put("price", "100").put("quantity", "1")
-        client.post(8080, "localhost", "/api/orders/$s1").sendJsonObject(buy)
+        val (ts, sig) = sign("POST", "/api/orders/$s1", buy.encode())
+        client.post(8080, "localhost", "/api/orders/$s1").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts).putHeader("X-VALR-SIGNATURE", sig).sendJsonObject(buy)
                 .compose { client.get(8080, "localhost", "/api/orderbook/$s2").send() }
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -167,4 +189,48 @@ class ApplicationTest {
                         }
                 )
     }
+
+    @Test
+    fun missingAuthReturns403(testContext: VertxTestContext) {
+        val symbol = "NOAUTH"
+        val order = JsonObject().put("side", "BUY").put("price", "1").put("quantity", "1")
+        client.post(8080, "localhost", "/api/orders/$symbol")
+                // No auth headers on purpose
+                .sendJsonObject(order)
+                .onComplete(
+                        testContext.succeeding<HttpResponse<Buffer>> { res ->
+                            assertEquals(403, res.statusCode())
+                            testContext.completeNow()
+                        }
+                )
+    }
+
+    @Test
+    fun wrongContentTypeReturns403(testContext: VertxTestContext) {
+        val symbol = "BADCT"
+        val payload = Buffer.buffer("side=BUY&price=1&quantity=1")
+        client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("content-type", "text/plain")
+                .sendBuffer(payload)
+                .onComplete(
+                        testContext.succeeding<HttpResponse<Buffer>> { res ->
+                            assertEquals(403, res.statusCode())
+                            testContext.completeNow()
+                        }
+                )
+    }
+}
+
+// ---- Test helpers ----
+private fun sign(verb: String, path: String, body: String = ""): Pair<String, String> {
+    val secret = "test-secret"
+    val ts = Clock.systemUTC().millis().toString()
+    val mac = Mac.getInstance("HmacSHA512")
+    mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA512"))
+    mac.update(ts.toByteArray())
+    mac.update(verb.uppercase().toByteArray())
+    mac.update(path.toByteArray())
+    mac.update(body.toByteArray())
+    val sig = mac.doFinal().joinToString(separator = "") { String.format("%02x", it) }
+    return ts to sig
 }

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -28,11 +28,17 @@ dependencies {
 
     testImplementation("io.vertx:vertx-junit5")
     testImplementation(kotlin("test"))
+    // Ensure JUnit 5 platform + API present
+    testImplementation(libs.junit.jupiter)
 }
 
 
 application {
     mainClass.set("com.valr.api.ApplicationKt")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 tasks.withType<Jar> {

--- a/api/src/main/kotlin/com/valr/api/Application.kt
+++ b/api/src/main/kotlin/com/valr/api/Application.kt
@@ -71,9 +71,11 @@ class ApiVerticle : CoroutineVerticle() {
             }
         }
 
-        // Submit limit order: /api/v1/orders/:symbol
+        // Submit limit order: /api/orders/:symbol (authenticated)
         // Body: { "side": "BUY|SELL", "price": "123.45", "quantity": "1.234" }
-        router.post("/api/orders/:symbol").handler { ctx ->
+        router.post("/api/orders/:symbol")
+                .handler(HmacAuthHandler())
+                .handler { ctx ->
             launch {
                 try {
                     val symbol = ctx.pathParam("symbol")

--- a/api/src/main/kotlin/com/valr/api/Auth.kt
+++ b/api/src/main/kotlin/com/valr/api/Auth.kt
@@ -1,0 +1,105 @@
+package com.valr.api
+
+import io.vertx.core.Handler
+import io.vertx.ext.web.RoutingContext
+import java.time.Clock
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/** Simple in-memory API key store (dev-only). */
+object ApiKeys {
+    private val keys: MutableMap<String, String> = mutableMapOf()
+
+    init {
+        // Load from env if present; otherwise seed a test key for local/dev usage.
+        val envKey = System.getenv("API_KEY")
+        val envSecret = System.getenv("API_SECRET")
+        if (!envKey.isNullOrBlank() && !envSecret.isNullOrBlank()) {
+            keys[envKey] = envSecret
+        } else {
+            keys["test-key"] = "test-secret"
+        }
+    }
+
+    fun secretFor(key: String): String? = keys[key]
+}
+
+/** HMAC (SHA-512) signer compatible with VALR-style concatenation. */
+object HmacSigner {
+    fun sign(secret: String, timestamp: String, verb: String, path: String, body: String): String {
+        val mac = Mac.getInstance("HmacSHA512")
+        mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA512"))
+        mac.update(timestamp.toByteArray())
+        mac.update(verb.uppercase().toByteArray())
+        mac.update(path.toByteArray())
+        mac.update(body.toByteArray())
+        val digest = mac.doFinal()
+        return digest.toHexLower()
+    }
+
+    private fun ByteArray.toHexLower(): String {
+        val sb = StringBuilder(this.size * 2)
+        for (b in this) sb.append(String.format("%02x", b))
+        return sb.toString()
+    }
+}
+
+/**
+ * Vert.x handler enforcing simple VALR-like HMAC auth for mutating requests.
+ * Requires headers: X-VALR-API-KEY, X-VALR-TIMESTAMP, X-VALR-SIGNATURE.
+ * Also enforces content-type application/json for POST/PUT/PATCH.
+ */
+class HmacAuthHandler(private val clock: Clock = Clock.systemUTC()) : Handler<RoutingContext> {
+    override fun handle(ctx: RoutingContext) {
+        val method = ctx.request().method()
+        // For mutating requests enforce JSON content-type
+        if (method.name() == "POST" || method.name() == "PUT" || method.name() == "PATCH") {
+            val ct = ctx.request().getHeader("content-type") ?: ""
+            if (!ct.lowercase().contains("application/json")) {
+                ctx.response()
+                        .setStatusCode(403)
+                        .putHeader("content-type", "application/json")
+                        .end(io.vertx.core.json.Json.encode(ErrorResponse("content-type must be application/json")))
+                return
+            }
+        }
+
+        val apiKey = ctx.request().getHeader("X-VALR-API-KEY")
+        val timestamp = ctx.request().getHeader("X-VALR-TIMESTAMP")
+        val providedSig = ctx.request().getHeader("X-VALR-SIGNATURE")
+
+        if (apiKey.isNullOrBlank() || timestamp.isNullOrBlank() || providedSig.isNullOrBlank()) {
+            ctx.response()
+                    .setStatusCode(403)
+                    .putHeader("content-type", "application/json")
+                    .end(io.vertx.core.json.Json.encode(ErrorResponse("Missing API authentication headers")))
+            return
+        }
+
+        val secret = ApiKeys.secretFor(apiKey)
+        if (secret == null) {
+            ctx.response()
+                    .setStatusCode(403)
+                    .putHeader("content-type", "application/json")
+                    .end(io.vertx.core.json.Json.encode(ErrorResponse("Invalid API key")))
+            return
+        }
+
+        val verb = method.name()
+        val path = ctx.request().path() // exclude host and query
+        val body = ctx.body().asString() ?: ""
+        val expected = HmacSigner.sign(secret, timestamp, verb, path, body)
+
+        if (!expected.equals(providedSig, ignoreCase = true)) {
+            ctx.response()
+                    .setStatusCode(403)
+                    .putHeader("content-type", "application/json")
+                    .end(io.vertx.core.json.Json.encode(ErrorResponse("Invalid signature")))
+            return
+        }
+
+        // Optionally, enforce timestamp freshness (skipped for simplicity in this assessment)
+        ctx.next()
+    }
+}
+

--- a/api/src/test/kotlin/com/valr/api/ApplicationTest.kt
+++ b/api/src/test/kotlin/com/valr/api/ApplicationTest.kt
@@ -8,6 +8,9 @@ import io.vertx.ext.web.client.HttpResponse
 import io.vertx.ext.web.client.WebClient
 import io.vertx.junit5.VertxExtension
 import io.vertx.junit5.VertxTestContext
+import java.time.Clock
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.*
@@ -53,10 +56,14 @@ class ApplicationTest {
     fun orderLifecycle(testContext: VertxTestContext) {
         val symbol = "TSTLIFE"
 
-        val buyOrder =
-                JsonObject().put("side", "BUY").put("price", "500000.00").put("quantity", "0.01")
+        val buyOrder = JsonObject().put("side", "BUY").put("price", "500000.00").put("quantity", "0.01")
+
+        val (ts, sig) = sign("POST", "/api/orders/$symbol", buyOrder.encode())
 
         client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("X-VALR-API-KEY", "test-key")
+                .putHeader("X-VALR-TIMESTAMP", ts)
+                .putHeader("X-VALR-SIGNATURE", sig)
                 .sendJsonObject(buyOrder)
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -84,7 +91,11 @@ class ApplicationTest {
     fun invalidSideReturns400(testContext: VertxTestContext) {
         val symbol = "TSTBAD"
         val badOrder = JsonObject().put("side", "BUYX").put("price", "1").put("quantity", "1")
+        val (ts, sig) = sign("POST", "/api/orders/$symbol", badOrder.encode())
         client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("X-VALR-API-KEY", "test-key")
+                .putHeader("X-VALR-TIMESTAMP", ts)
+                .putHeader("X-VALR-SIGNATURE", sig)
                 .sendJsonObject(badOrder)
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -100,7 +111,11 @@ class ApplicationTest {
     fun missingFieldsReturnError(testContext: VertxTestContext) {
         val symbol = "TSTMISS"
         val badOrder = JsonObject().put("side", "BUY").put("price", "1") // missing quantity
+        val (ts, sig) = sign("POST", "/api/orders/$symbol", badOrder.encode())
         client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("X-VALR-API-KEY", "test-key")
+                .putHeader("X-VALR-TIMESTAMP", ts)
+                .putHeader("X-VALR-SIGNATURE", sig)
                 .sendJsonObject(badOrder)
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -115,9 +130,13 @@ class ApplicationTest {
         val symbol = "TSTDEPTH"
         val mk = { p: String -> JsonObject().put("side", "BUY").put("price", p).put("quantity", "0.01") }
 
-        client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(mk("100"))
-                .compose { client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(mk("200")) }
-                .compose { client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(mk("300")) }
+        val (ts1, sig1) = sign("POST", "/api/orders/$symbol", mk("100").encode())
+        val (ts2, sig2) = sign("POST", "/api/orders/$symbol", mk("200").encode())
+        val (ts3, sig3) = sign("POST", "/api/orders/$symbol", mk("300").encode())
+
+        client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts1).putHeader("X-VALR-SIGNATURE", sig1).sendJsonObject(mk("100"))
+                .compose { client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts2).putHeader("X-VALR-SIGNATURE", sig2).sendJsonObject(mk("200")) }
+                .compose { client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts3).putHeader("X-VALR-SIGNATURE", sig3).sendJsonObject(mk("300")) }
                 .compose { client.get(8080, "localhost", "/api/orderbook/$symbol?depth=2").send() }
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -135,8 +154,10 @@ class ApplicationTest {
         val symbol = "TSTTRADES"
         val sell = JsonObject().put("side", "SELL").put("price", "10").put("quantity", "1")
         val buy = JsonObject().put("side", "BUY").put("price", "10").put("quantity", "1")
-        client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(sell)
-                .compose { client.post(8080, "localhost", "/api/orders/$symbol").sendJsonObject(buy) }
+        val (ts1, sig1) = sign("POST", "/api/orders/$symbol", sell.encode())
+        val (ts2, sig2) = sign("POST", "/api/orders/$symbol", buy.encode())
+        client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts1).putHeader("X-VALR-SIGNATURE", sig1).sendJsonObject(sell)
+                .compose { client.post(8080, "localhost", "/api/orders/$symbol").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts2).putHeader("X-VALR-SIGNATURE", sig2).sendJsonObject(buy) }
                 .compose { client.get(8080, "localhost", "/api/trades/$symbol?limit=1").send() }
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -153,7 +174,8 @@ class ApplicationTest {
         val s1 = "AAAUSD"
         val s2 = "BBBUSD"
         val buy = JsonObject().put("side", "BUY").put("price", "100").put("quantity", "1")
-        client.post(8080, "localhost", "/api/orders/$s1").sendJsonObject(buy)
+        val (ts, sig) = sign("POST", "/api/orders/$s1", buy.encode())
+        client.post(8080, "localhost", "/api/orders/$s1").putHeader("X-VALR-API-KEY", "test-key").putHeader("X-VALR-TIMESTAMP", ts).putHeader("X-VALR-SIGNATURE", sig).sendJsonObject(buy)
                 .compose { client.get(8080, "localhost", "/api/orderbook/$s2").send() }
                 .onComplete(
                         testContext.succeeding<HttpResponse<Buffer>> { res ->
@@ -167,4 +189,48 @@ class ApplicationTest {
                         }
                 )
     }
+
+    @Test
+    fun missingAuthReturns403(testContext: VertxTestContext) {
+        val symbol = "NOAUTH"
+        val order = JsonObject().put("side", "BUY").put("price", "1").put("quantity", "1")
+        client.post(8080, "localhost", "/api/orders/$symbol")
+                // No auth headers on purpose
+                .sendJsonObject(order)
+                .onComplete(
+                        testContext.succeeding<HttpResponse<Buffer>> { res ->
+                            assertEquals(403, res.statusCode())
+                            testContext.completeNow()
+                        }
+                )
+    }
+
+    @Test
+    fun wrongContentTypeReturns403(testContext: VertxTestContext) {
+        val symbol = "BADCT"
+        val payload = Buffer.buffer("side=BUY&price=1&quantity=1")
+        client.post(8080, "localhost", "/api/orders/$symbol")
+                .putHeader("content-type", "text/plain")
+                .sendBuffer(payload)
+                .onComplete(
+                        testContext.succeeding<HttpResponse<Buffer>> { res ->
+                            assertEquals(403, res.statusCode())
+                            testContext.completeNow()
+                        }
+                )
+    }
+}
+
+// ---- Test helpers ----
+private fun sign(verb: String, path: String, body: String = ""): Pair<String, String> {
+    val secret = "test-secret"
+    val ts = Clock.systemUTC().millis().toString()
+    val mac = Mac.getInstance("HmacSHA512")
+    mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA512"))
+    mac.update(ts.toByteArray())
+    mac.update(verb.uppercase().toByteArray())
+    mac.update(path.toByteArray())
+    mac.update(body.toByteArray())
+    val sig = mac.doFinal().joinToString(separator = "") { String.format("%02x", it) }
+    return ts to sig
 }


### PR DESCRIPTION
> api: add VALR-style HMAC auth for orders; enforce application/json

  - Introduce HmacAuthHandler + HmacSigner and simple ApiKeys store
      - Headers: X-VALR-API-KEY, X-VALR-TIMESTAMP, X-VALR-SIGNATURE
      - Signature: HMAC-SHA512 over timestamp + verb + path + body
      - Enforce content-type application/json for POST/PUT/PATCH (403 on violation)
      - Load API_KEY/API_SECRET from env, fallback to dev defaults (test-key/test-secret)
  - Attach auth handler to POST /api/orders/:symbol
  - Update API tests to sign requests; add tests:
      - missingAuthReturns403
      - wrongContentTypeReturns403
  - build(api): ensure JUnit 5 platform for tests (useJUnitPlatform + junit-jupiter dep)

  docs: document auth and examples; update status, TOC, roadmap

  - Add Authentication section with signing details and bash/openssl example
  - Document Docker usage with custom API keys
  - Update status to include HMAC auth
  - Update Table of Contents (Authentication, API Docs)
  - Prune Roadmap items already implemented (Auth, depth param)

  Testing

  - Ran: ./gradlew :engine:test :api:test — all tests pass