### PR TITLE
Updated openAPI spec | Added timeInForce to engine and api | Updated …

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ curl -s http://localhost:8080/healthz
 - Implement a working in-memory order book with price–time priority and order matching.
 - Provide an HTTP API to:
     - Get order book (aggregated price levels).
-    - Submit limit orders.
+    - Submit limit orders (GTC/IOC/FOK).
     - Get recent trades.
 - Include unit tests for the engine and light integration tests for the API.
 - Favor clarity and extensibility over premature micro-optimizations.
@@ -132,6 +132,21 @@ curl -sS -X POST "http://localhost:8080$PATH" \
 ```
 
 Expected response: JSON object containing the `order` and any resulting `trades`.
+
+### Time In Force
+
+- Supported values: `GTC` (default), `IOC`, `FOK`.
+- Request field: add `timeInForce` to the order body.
+- Semantics:
+  - `GTC`: match immediately, rest remainder on the book.
+  - `IOC`: match immediately, cancel any remainder (do not rest).
+  - `FOK`: if full quantity cannot be matched immediately, cancel the entire order (no trades).
+
+Example body with IOC:
+
+```json
+{ "side": "BUY", "price": "100", "quantity": "0.5", "timeInForce": "IOC" }
+```
 
 ### Docker with custom keys
 

--- a/api/bin/main/openapi.yaml
+++ b/api/bin/main/openapi.yaml
@@ -9,6 +9,8 @@ paths:
   /healthz:
     get:
       summary: Health check
+      operationId: healthz
+      tags: [System]
       responses:
         "200":
           description: OK
@@ -16,6 +18,8 @@ paths:
   /api/orderbook/{symbol}:
     get:
       summary: Get order book snapshot
+      operationId: getOrderBook
+      tags: [OrderBook]
       parameters:
         - name: symbol
           in: path
@@ -24,40 +28,83 @@ paths:
         - name: depth
           in: query
           required: false
-          schema: { type: integer }
+          description: Number of levels to return on each side (top-N)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 50
       responses:
         "200":
           description: Snapshot
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderBookSnapshot'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/orders/{symbol}:
     post:
       summary: Submit limit order
+      operationId: submitOrder
+      tags: [Orders]
       parameters:
         - name: symbol
           in: path
           required: true
           schema: { type: string }
+        - $ref: '#/components/parameters/ApiKeyHeader'
+        - $ref: '#/components/parameters/TimestampHeader'
+        - $ref: '#/components/parameters/SignatureHeader'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                side: { type: string, enum: [BUY, SELL] }
-                price: { type: number }
-                quantity: { type: number }
+              $ref: '#/components/schemas/SubmitOrderRequest'
+            examples:
+              gtc:
+                value: { side: BUY, price: "100", quantity: "0.5" }
+              ioc:
+                value: { side: BUY, price: "100", quantity: "0.5", timeInForce: IOC }
+              fok:
+                value: { side: BUY, price: "100", quantity: "0.5", timeInForce: FOK }
       responses:
         "200":
           description: Created order + trades
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitOrderResponse'
+         "403":
+           description: Forbidden (missing/invalid auth headers or wrong content-type)
+           content:
+             application/json:
+               schema:
+                 $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/trades/{symbol}:
     get:
       summary: Recent trades
+      operationId: getRecentTrades
+      tags: [Trades]
       parameters:
         - name: symbol
           in: path
@@ -65,9 +112,125 @@ paths:
           schema: { type: string }
         - name: limit
           in: query
-          schema: { type: integer }
+          description: Number of recent trades to return (newest first)
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+            default: 50
       responses:
         "200":
           description: List of trades
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Trade'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-VALR-API-KEY
+      description: API key identifier
+  parameters:
+    ApiKeyHeader:
+      name: X-VALR-API-KEY
+      in: header
+      required: true
+      description: API key identifier
+      schema: { type: string }
+    TimestampHeader:
+      name: X-VALR-TIMESTAMP
+      in: header
+      required: true
+      description: Unix timestamp in milliseconds, as a string
+      schema: { type: string }
+    SignatureHeader:
+      name: X-VALR-SIGNATURE
+      in: header
+      required: true
+      description: Hex HMAC-SHA512 of timestamp + verb + path + body using the API secret
+      schema: { type: string }
+  schemas:
+    SubmitOrderRequest:
+      type: object
+      required: [side, price, quantity]
+      properties:
+        side: { type: string, enum: [BUY, SELL] }
+        price:
+          type: string
+          description: Price as string to preserve decimal precision
+          example: "100.00"
+        quantity:
+          type: string
+          description: Quantity as string to preserve decimal precision
+          example: "0.50"
+        timeInForce:
+          type: string
+          description: Time in force for the order
+          enum: [GTC, IOC, FOK]
+          default: GTC
+    SubmitOrderResponse:
+      type: object
+      properties:
+        order:
+          $ref: '#/components/schemas/Order'
+        trades:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trade'
+    Order:
+      type: object
+      properties:
+        id: { type: string }
+        symbol: { type: string }
+        side: { type: string, enum: [BUY, SELL] }
+        price: { type: string }
+        quantity: { type: string }
+        remaining: { type: string }
+        timestamp: { type: integer, format: int64 }
+        timeInForce: { type: string, enum: [GTC, IOC, FOK] }
+    Trade:
+      type: object
+      properties:
+        id: { type: string }
+        price: { type: string }
+        quantity: { type: string }
+        takerOrderId: { type: string }
+        makerOrderId: { type: string }
+        timestamp: { type: integer, format: int64 }
+    Level:
+      type: object
+      properties:
+        price: { type: string }
+        quantity: { type: string }
+    OrderBookSnapshot:
+      type: object
+      properties:
+        symbol: { type: string }
+        bids:
+          type: array
+          description: Sorted descending (best bid first)
+          items:
+            $ref: '#/components/schemas/Level'
+        asks:
+          type: array
+          description: Sorted ascending (best ask first)
+          items:
+            $ref: '#/components/schemas/Level'
+    ErrorResponse:
+      type: object
+      properties:
+        error: { type: string }
+        details:
+          type: string
+          nullable: true

--- a/api/src/main/resources/openapi.yaml
+++ b/api/src/main/resources/openapi.yaml
@@ -9,6 +9,8 @@ paths:
   /healthz:
     get:
       summary: Health check
+      operationId: healthz
+      tags: [System]
       responses:
         "200":
           description: OK
@@ -16,6 +18,8 @@ paths:
   /api/orderbook/{symbol}:
     get:
       summary: Get order book snapshot
+      operationId: getOrderBook
+      tags: [OrderBook]
       parameters:
         - name: symbol
           in: path
@@ -24,40 +28,83 @@ paths:
         - name: depth
           in: query
           required: false
-          schema: { type: integer }
+          description: Number of levels to return on each side (top-N)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 50
       responses:
         "200":
           description: Snapshot
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderBookSnapshot'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/orders/{symbol}:
     post:
       summary: Submit limit order
+      operationId: submitOrder
+      tags: [Orders]
       parameters:
         - name: symbol
           in: path
           required: true
           schema: { type: string }
+        - $ref: '#/components/parameters/ApiKeyHeader'
+        - $ref: '#/components/parameters/TimestampHeader'
+        - $ref: '#/components/parameters/SignatureHeader'
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                side: { type: string, enum: [BUY, SELL] }
-                price: { type: number }
-                quantity: { type: number }
+              $ref: '#/components/schemas/SubmitOrderRequest'
+            examples:
+              gtc:
+                value: { side: BUY, price: "100", quantity: "0.5" }
+              ioc:
+                value: { side: BUY, price: "100", quantity: "0.5", timeInForce: IOC }
+              fok:
+                value: { side: BUY, price: "100", quantity: "0.5", timeInForce: FOK }
       responses:
         "200":
           description: Created order + trades
           content:
-            application/json: {}
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmitOrderResponse'
+         "403":
+           description: Forbidden (missing/invalid auth headers or wrong content-type)
+           content:
+             application/json:
+               schema:
+                 $ref: '#/components/schemas/ErrorResponse'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "500":
+          description: Server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /api/trades/{symbol}:
     get:
       summary: Recent trades
+      operationId: getRecentTrades
+      tags: [Trades]
       parameters:
         - name: symbol
           in: path
@@ -65,9 +112,125 @@ paths:
           schema: { type: string }
         - name: limit
           in: query
-          schema: { type: integer }
+          description: Number of recent trades to return (newest first)
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+            default: 50
       responses:
         "200":
           description: List of trades
           content:
-            application/json: {}
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Trade'
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  securitySchemes:
+    ApiKeyHeader:
+      type: apiKey
+      in: header
+      name: X-VALR-API-KEY
+      description: API key identifier
+  parameters:
+    ApiKeyHeader:
+      name: X-VALR-API-KEY
+      in: header
+      required: true
+      description: API key identifier
+      schema: { type: string }
+    TimestampHeader:
+      name: X-VALR-TIMESTAMP
+      in: header
+      required: true
+      description: Unix timestamp in milliseconds, as a string
+      schema: { type: string }
+    SignatureHeader:
+      name: X-VALR-SIGNATURE
+      in: header
+      required: true
+      description: Hex HMAC-SHA512 of timestamp + verb + path + body using the API secret
+      schema: { type: string }
+  schemas:
+    SubmitOrderRequest:
+      type: object
+      required: [side, price, quantity]
+      properties:
+        side: { type: string, enum: [BUY, SELL] }
+        price:
+          type: string
+          description: Price as string to preserve decimal precision
+          example: "100.00"
+        quantity:
+          type: string
+          description: Quantity as string to preserve decimal precision
+          example: "0.50"
+        timeInForce:
+          type: string
+          description: Time in force for the order
+          enum: [GTC, IOC, FOK]
+          default: GTC
+    SubmitOrderResponse:
+      type: object
+      properties:
+        order:
+          $ref: '#/components/schemas/Order'
+        trades:
+          type: array
+          items:
+            $ref: '#/components/schemas/Trade'
+    Order:
+      type: object
+      properties:
+        id: { type: string }
+        symbol: { type: string }
+        side: { type: string, enum: [BUY, SELL] }
+        price: { type: string }
+        quantity: { type: string }
+        remaining: { type: string }
+        timestamp: { type: integer, format: int64 }
+        timeInForce: { type: string, enum: [GTC, IOC, FOK] }
+    Trade:
+      type: object
+      properties:
+        id: { type: string }
+        price: { type: string }
+        quantity: { type: string }
+        takerOrderId: { type: string }
+        makerOrderId: { type: string }
+        timestamp: { type: integer, format: int64 }
+    Level:
+      type: object
+      properties:
+        price: { type: string }
+        quantity: { type: string }
+    OrderBookSnapshot:
+      type: object
+      properties:
+        symbol: { type: string }
+        bids:
+          type: array
+          description: Sorted descending (best bid first)
+          items:
+            $ref: '#/components/schemas/Level'
+        asks:
+          type: array
+          description: Sorted ascending (best ask first)
+          items:
+            $ref: '#/components/schemas/Level'
+    ErrorResponse:
+      type: object
+      properties:
+        error: { type: string }
+        details:
+          type: string
+          nullable: true

--- a/engine/bin/main/com/valr/engine/model/Order.kt
+++ b/engine/bin/main/com/valr/engine/model/Order.kt
@@ -9,5 +9,6 @@ data class Order(
     val price: BigDecimal,
     val quantity: BigDecimal,
     var remaining: BigDecimal,
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val timeInForce: TimeInForce = TimeInForce.GTC
 )

--- a/engine/bin/main/com/valr/engine/model/TimeInForce.kt
+++ b/engine/bin/main/com/valr/engine/model/TimeInForce.kt
@@ -1,0 +1,8 @@
+package com.valr.engine.model
+
+enum class TimeInForce {
+    GTC, // Good-Till-Cancelled (default)
+    IOC, // Immediate-Or-Cancel (no rest)
+    FOK  // Fill-Or-Kill (all-or-nothing)
+}
+

--- a/engine/bin/test/com/valr/engine/OrderBookTimeInForceTest.kt
+++ b/engine/bin/test/com/valr/engine/OrderBookTimeInForceTest.kt
@@ -1,0 +1,65 @@
+package com.valr.engine
+
+import com.valr.engine.core.OrderBook
+import com.valr.engine.model.Order
+import com.valr.engine.model.Side
+import com.valr.engine.model.TimeInForce
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class OrderBookTimeInForceTest {
+
+    private fun bd(s: String) = BigDecimal(s)
+
+    @Test
+    fun `IOC matches immediately and cancels remainder (no rest)`() {
+        val ob = OrderBook("BTCZAR")
+        // Rest 0.3 on ask at 100
+        ob.placeOrder(Order("s1", "BTCZAR", Side.SELL, bd("100"), bd("0.3"), bd("0.3")))
+
+        // IOC buy 0.5 @ 100 should match 0.3 and not rest 0.2
+        val trades = ob.placeOrder(
+                Order("b1", "BTCZAR", Side.BUY, bd("100"), bd("0.5"), bd("0.5"), timeInForce = TimeInForce.IOC)
+        )
+        assertEquals(1, trades.size)
+        // Snapshot should have no bids (remainder 0.2 must not rest)
+        val snap = ob.snapshot()
+        assertTrue(snap.bids.isEmpty(), "IOC remainder should not rest on book")
+    }
+
+    @Test
+    fun `FOK not fully fillable cancels with no trades and no mutation`() {
+        val ob = OrderBook("BTCZAR")
+        // Only 0.3 available on asks at or below 100
+        ob.placeOrder(Order("s1", "BTCZAR", Side.SELL, bd("100"), bd("0.3"), bd("0.3")))
+
+        val trades = ob.placeOrder(
+                Order("b1", "BTCZAR", Side.BUY, bd("100"), bd("0.5"), bd("0.5"), timeInForce = TimeInForce.FOK)
+        )
+        assertTrue(trades.isEmpty(), "FOK should produce no trades if not fully fillable")
+        // Book must remain unchanged (ask still there, no bids added)
+        val snap = ob.snapshot()
+        assertTrue(snap.bids.isEmpty())
+        assertEquals(1, snap.asks.size)
+        assertEquals(bd("0.3"), snap.asks.first().quantity)
+    }
+
+    @Test
+    fun `FOK fully fillable executes entirely with no rest`() {
+        val ob = OrderBook("BTCZAR")
+        // 0.3 @ 100 and 0.2 @ 99 are eligible for buy @100
+        ob.placeOrder(Order("s1", "BTCZAR", Side.SELL, bd("100"), bd("0.3"), bd("0.3")))
+        ob.placeOrder(Order("s2", "BTCZAR", Side.SELL, bd("99"), bd("0.2"), bd("0.2")))
+
+        val trades = ob.placeOrder(
+                Order("b1", "BTCZAR", Side.BUY, bd("100"), bd("0.5"), bd("0.5"), timeInForce = TimeInForce.FOK)
+        )
+        assertEquals(2, trades.size)
+        val snap = ob.snapshot()
+        // No remaining bids or asks at those exact levels
+        assertTrue(snap.bids.isEmpty())
+        assertTrue(snap.asks.isEmpty())
+    }
+}
+

--- a/engine/src/main/kotlin/com/valr/engine/model/Order.kt
+++ b/engine/src/main/kotlin/com/valr/engine/model/Order.kt
@@ -9,5 +9,6 @@ data class Order(
     val price: BigDecimal,
     val quantity: BigDecimal,
     var remaining: BigDecimal,
-    val timestamp: Long = System.currentTimeMillis()
+    val timestamp: Long = System.currentTimeMillis(),
+    val timeInForce: TimeInForce = TimeInForce.GTC
 )

--- a/engine/src/main/kotlin/com/valr/engine/model/TimeInForce.kt
+++ b/engine/src/main/kotlin/com/valr/engine/model/TimeInForce.kt
@@ -1,0 +1,8 @@
+package com.valr.engine.model
+
+enum class TimeInForce {
+    GTC, // Good-Till-Cancelled (default)
+    IOC, // Immediate-Or-Cancel (no rest)
+    FOK  // Fill-Or-Kill (all-or-nothing)
+}
+

--- a/engine/src/test/kotlin/com/valr/engine/OrderBookTimeInForceTest.kt
+++ b/engine/src/test/kotlin/com/valr/engine/OrderBookTimeInForceTest.kt
@@ -1,0 +1,65 @@
+package com.valr.engine
+
+import com.valr.engine.core.OrderBook
+import com.valr.engine.model.Order
+import com.valr.engine.model.Side
+import com.valr.engine.model.TimeInForce
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class OrderBookTimeInForceTest {
+
+    private fun bd(s: String) = BigDecimal(s)
+
+    @Test
+    fun `IOC matches immediately and cancels remainder (no rest)`() {
+        val ob = OrderBook("BTCZAR")
+        // Rest 0.3 on ask at 100
+        ob.placeOrder(Order("s1", "BTCZAR", Side.SELL, bd("100"), bd("0.3"), bd("0.3")))
+
+        // IOC buy 0.5 @ 100 should match 0.3 and not rest 0.2
+        val trades = ob.placeOrder(
+                Order("b1", "BTCZAR", Side.BUY, bd("100"), bd("0.5"), bd("0.5"), timeInForce = TimeInForce.IOC)
+        )
+        assertEquals(1, trades.size)
+        // Snapshot should have no bids (remainder 0.2 must not rest)
+        val snap = ob.snapshot()
+        assertTrue(snap.bids.isEmpty(), "IOC remainder should not rest on book")
+    }
+
+    @Test
+    fun `FOK not fully fillable cancels with no trades and no mutation`() {
+        val ob = OrderBook("BTCZAR")
+        // Only 0.3 available on asks at or below 100
+        ob.placeOrder(Order("s1", "BTCZAR", Side.SELL, bd("100"), bd("0.3"), bd("0.3")))
+
+        val trades = ob.placeOrder(
+                Order("b1", "BTCZAR", Side.BUY, bd("100"), bd("0.5"), bd("0.5"), timeInForce = TimeInForce.FOK)
+        )
+        assertTrue(trades.isEmpty(), "FOK should produce no trades if not fully fillable")
+        // Book must remain unchanged (ask still there, no bids added)
+        val snap = ob.snapshot()
+        assertTrue(snap.bids.isEmpty())
+        assertEquals(1, snap.asks.size)
+        assertEquals(bd("0.3"), snap.asks.first().quantity)
+    }
+
+    @Test
+    fun `FOK fully fillable executes entirely with no rest`() {
+        val ob = OrderBook("BTCZAR")
+        // 0.3 @ 100 and 0.2 @ 99 are eligible for buy @100
+        ob.placeOrder(Order("s1", "BTCZAR", Side.SELL, bd("100"), bd("0.3"), bd("0.3")))
+        ob.placeOrder(Order("s2", "BTCZAR", Side.SELL, bd("99"), bd("0.2"), bd("0.2")))
+
+        val trades = ob.placeOrder(
+                Order("b1", "BTCZAR", Side.BUY, bd("100"), bd("0.5"), bd("0.5"), timeInForce = TimeInForce.FOK)
+        )
+        assertEquals(2, trades.size)
+        val snap = ob.snapshot()
+        // No remaining bids or asks at those exact levels
+        assertTrue(snap.bids.isEmpty())
+        assertTrue(snap.asks.isEmpty())
+    }
+}
+


### PR DESCRIPTION
- Engine
      - Added TimeInForce enum: GTC, IOC, FOK (engine/src/main/kotlin/.../TimeInForce.kt).
      - Extended Order with timeInForce: TimeInForce = GTC for backward compatibility.
      - Updated OrderBook:
          - submitLimitOrder(...) accepts timeInForce.
          - placeOrder(...):
              - FOK pre-check: read-only scan of eligible levels to ensure full fill; cancel if not
  possible (no trades, no mutation).
              - IOC: match immediately; do not rest any remainder.
              - GTC: current behavior (match then rest).
          - Added canFullyFill(...) helper mirroring eligibility logic.
  - API
      - SubmitOrderRequest includes optional timeInForce with validation and mapping to enum.
      - POST /api/orders/:symbol passes timeInForce to the engine.
  - Tests
      - Engine: new OrderBookTimeInForceTest covering:
          - IOC remainder not resting.
          - FOK cancels when not fully fillable (no trades; book unchanged).
          - FOK fully fillable executes entirely (no rest).
      - API: added iocDoesNotRestRemainder integration test.
  - Documentation
      - README:
          - Goals now mention GTC/IOC/FOK.
          - Added “Time In Force” section with semantics and example payloads.
      - OpenAPI (api/src/main/resources/openapi.yaml):
          - Added timeInForce (enum + default) to order request with examples.
          - Introduced reusable components (schemas for Order, Trade, Level, OrderBookSnapshot,
  ErrorResponse; header parameters).
          - Tightened query param constraints (depth, limit) and referenced response schemas.